### PR TITLE
Don't ever try to lookup the UserInfo object for staff User accounts.

### DIFF
--- a/SigmaPi/Secure/templates/secure_base.html
+++ b/SigmaPi/Secure/templates/secure_base.html
@@ -95,11 +95,12 @@
       				<span class="caret"></span>
       			</a>
       			<ul class="dropdown-menu" role="menu">
+							{% if user.is_staff %}
+                <li><a href="/admin/">Admin Panel</a>
+							{% else %}
 		            <li><a href="{% url 'UserInfo.views.edit_user' user.username %}">Edit Profile</a></li>
 		            <li><a href="{% url 'UserInfo.views.change_password' %}">Change Password</a></li>
-		            {% if user.is_staff %}
-		            <li><a href="/admin/">Admin</a>
-		            {% endif %}
+              {% endif %}
 		            <li class="divider"></li>
 		            <li><a href="/logout/">Logout</a></li>
 		        </ul>

--- a/SigmaPi/UserInfo/templates/secure/manage_users.html
+++ b/SigmaPi/UserInfo/templates/secure/manage_users.html
@@ -25,6 +25,7 @@
 		</thead>
 		<tbody>
 			{% for user in all_users %}
+			{% if not user.is_staff %}
 			<tr>
 				<td>{{ user.first_name }}</td>
 				<td>{{ user.last_name }}</td>
@@ -36,6 +37,7 @@
 					<a href="{% url 'UserInfo.views.reset_password' user.username %}">Reset</a>
 				</td>
 			</tr>
+			{% endif %}
 			{% endfor %}
 		</tbody>
 	</table>


### PR DESCRIPTION
This should stop the exceptions we're getting when an admin user without a UserProfile logs in.

Afterwards, you should create admin accounts for everyone. Make them staff + superusers, and no need for a UserProfile.